### PR TITLE
Preload next/previous videos for instant play

### DIFF
--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -31,9 +31,19 @@ export default function VideoFeed() {
       return (
         <div className="p-6 text-center text-white/70">Loading videos…</div>
       );
-    return videos.map((v, i) => (
-      <VideoCard key={v.id || v.src} item={v} index={i} onVisible={setCurrent} />
-    ));
+    const preloadAhead = 2;
+    return videos.map((v, i) => {
+      const preload = i > current && i <= current + preloadAhead;
+      return (
+        <VideoCard
+          key={v.id || v.src}
+          item={v}
+          index={i}
+          onVisible={setCurrent}
+          preload={preload}
+        />
+      );
+    });
   }, [videos, error]);
 
   // Helper to scroll to an index

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -23,7 +23,9 @@ export default function VideoFeed() {
       .catch((e) => setError(String(e)));
   }, []);
 
-  useVideoPreloader(videos, current, 2);
+  const PRELOAD_AHEAD = Number((import.meta as any).env?.VITE_PRELOAD_AHEAD ?? 2);
+  const PRELOAD_BEHIND = Number((import.meta as any).env?.VITE_PRELOAD_BEHIND ?? 1);
+  useVideoPreloader(videos, current, PRELOAD_AHEAD, PRELOAD_BEHIND);
 
   const content = useMemo(() => {
     if (error) return <div className="p-4 text-red-400">{error}</div>;
@@ -31,9 +33,9 @@ export default function VideoFeed() {
       return (
         <div className="p-6 text-center text-white/70">Loading videos…</div>
       );
-    const preloadAhead = 2;
     return videos.map((v, i) => {
-      const preload = i > current && i <= current + preloadAhead;
+      const preload = (i > current && i <= current + PRELOAD_AHEAD) ||
+                      (i < current && i >= current - PRELOAD_BEHIND);
       return (
         <VideoCard
           key={v.id || v.src}
@@ -44,7 +46,7 @@ export default function VideoFeed() {
         />
       );
     });
-  }, [videos, error]);
+  }, [videos, error, current]);
 
   // Helper to scroll to an index
   const scrollToIndex = (idx: number) => {

--- a/src/hooks/useVideoPreloader.ts
+++ b/src/hooks/useVideoPreloader.ts
@@ -4,14 +4,21 @@ import type { VideoItem } from "../types";
 export function useVideoPreloader(
   videos: VideoItem[],
   currentIndex: number,
-  preloadCount = 2
+  preloadAhead = 2,
+  preloadBehind = 1
 ) {
   const cache = useRef<Map<string, HTMLVideoElement>>(new Map());
 
   useEffect(() => {
-    const start = Math.max(0, currentIndex + 1);
-    const end = Math.min(videos.length, currentIndex + 1 + preloadCount);
-    const toPreload = videos.slice(start, end);
+    const aheadStart = Math.max(0, currentIndex + 1);
+    const aheadEnd = Math.min(videos.length, currentIndex + 1 + preloadAhead);
+    const behindStart = Math.max(0, currentIndex - preloadBehind);
+    const behindEnd = Math.max(0, currentIndex); // exclusive of current
+
+    const set = new Map<string, VideoItem>();
+    videos.slice(aheadStart, aheadEnd).forEach((v) => set.set(v.src, v));
+    videos.slice(behindStart, behindEnd).forEach((v) => set.set(v.src, v));
+    const toPreload = Array.from(set.values());
 
     toPreload.forEach((v) => {
       if (!cache.current.has(v.src)) {
@@ -40,7 +47,7 @@ export function useVideoPreloader(
         }
       }
     };
-  }, [videos, currentIndex, preloadCount]);
+  }, [videos, currentIndex, preloadAhead, preloadBehind]);
 
   return cache.current;
 }

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -32,9 +32,10 @@ export function toVimeoId(url: string): string | null {
   return null;
 }
 
-export function makeYouTubeEmbed(id: string): string {
+export function makeYouTubeEmbed(id: string, opts?: { autoplay?: boolean }): string {
+  const autoplay = opts?.autoplay ?? true;
   const params = new URLSearchParams({
-    autoplay: '1',
+    autoplay: autoplay ? '1' : '0',
     mute: '1',
     loop: '1',
     playlist: id,
@@ -51,9 +52,10 @@ export function makeYouTubeEmbed(id: string): string {
   return `https://www.youtube-nocookie.com/embed/${id}?${params.toString()}`;
 }
 
-export function makeVimeoEmbed(id: string): string {
+export function makeVimeoEmbed(id: string, opts?: { autoplay?: boolean }): string {
+  const autoplay = opts?.autoplay ?? true;
   const params = new URLSearchParams({
-    autoplay: '1',
+    autoplay: autoplay ? '1' : '0',
     muted: '1',
     loop: '1',
     background: '1', // hides controls/UI


### PR DESCRIPTION
This PR improves startup latency between items by preloading both ahead and behind.

What’s included
- Preload ahead/behind: Configurable via env (, ). Defaults: ahead=2, behind=1.
- HTML5 videos: Preload buffer () for items within the window.
- YouTube/Vimeo: Pre-mount offscreen iframes (autoplay disabled) for next/previous items, so play begins instantly when visible.
- Stable player reuse: If an item was preloaded, its iframe instance is reused when it becomes active.

Files
- src/components/VideoFeed.tsx: marks items to preload ahead/behind, reads env.
- src/components/VideoCard.tsx: supports  prop, handles offscreen embeds and video preload.
- src/hooks/useVideoPreloader.ts: preloads adjacent HTML5 sources both directions.
- src/utils/embed.ts: embed helpers accept .

Follow-ups
- Tweak defaults in  if desired.
- Optional: add metric for time-to-play after navigation.
