### PR TITLE
Add /videos page with alternate Google Sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Video Feed</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,26 @@
 import './App.css'
 import VideoFeed from './components/VideoFeed'
+import { useMemo } from 'react'
 
 function App() {
+  const base = (import.meta as any).env?.BASE_URL || '/';
+  const path = useMemo(() => {
+    const p = window.location.pathname;
+    return p.startsWith(base) ? p.slice(base.length - 1) : p; // keep leading '/'
+  }, [base]);
+
+  const sheetForVideos = 'https://docs.google.com/spreadsheets/d/1wQUswabehFQq0pEJADeF3_b-6GsqNVAygy22yBG5OeE/edit?gid=0#gid=0';
+
+  const source = useMemo(() => {
+    if (path === '/videos') {
+      return { sheetCsvUrl: sheetForVideos };
+    }
+    return undefined;
+  }, [path]);
+
   return (
     <div className="h-full">
-      <VideoFeed />
+      <VideoFeed source={source} />
     </div>
   )
 }

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -1,11 +1,15 @@
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { loadVideos } from "../data/sources";
+import { loadVideos, type LoadOptions } from "../data/sources";
 import type { VideoItem } from "../types";
 import { useVideoPreloader } from "../hooks/useVideoPreloader";
 import VideoCard from "./VideoCard";
 
-export default function VideoFeed() {
+type FeedProps = {
+  source?: LoadOptions;
+};
+
+export default function VideoFeed({ source }: FeedProps) {
   const [videos, setVideos] = useState<VideoItem[]>([]);
   const [current, setCurrent] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -18,10 +22,10 @@ export default function VideoFeed() {
   const isDraggingRef = useRef(false);
 
   useEffect(() => {
-    loadVideos()
+    loadVideos(source)
       .then((v) => setVideos(v))
       .catch((e) => setError(String(e)));
-  }, []);
+  }, [source]);
 
   const PRELOAD_AHEAD = Number((import.meta as any).env?.VITE_PRELOAD_AHEAD ?? 2);
   const PRELOAD_BEHIND = Number((import.meta as any).env?.VITE_PRELOAD_BEHIND ?? 1);


### PR DESCRIPTION
This adds a new page at /videos that loads from a different Google Sheet (link provided), while keeping the existing homepage feed intact.\n\nHighlights\n- Lightweight routing: Detects path using BASE_URL-safe logic.\n- Configurable loader:  now accepts a  and optional .\n- Google Sheets support: Converts edit links to CSV export automatically.\n- GH Pages-safe paths:  fetch honors .\n\nHow to test\n- / (root): uses default sources (env  + ).\n- /videos: uses the provided Sheet; instantly available on GH Pages at /video-feed/videos.\n\nFollow-ups\n- If you want more pages, we can promote the simple router to a tiny mapping function or add react-router later if needed.\n